### PR TITLE
改进 display: inline-block; 插入 hack 代码的方式

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -321,18 +321,36 @@ function ieRgbaHack(decl, i) {
 function ieInlineBlockHack(decl, i) {
   if (decl.prop == 'display' && decl.value == 'inline-block') {
 
-    var reBefore = decl.before.replace(reBLANK_LINE, '$1')
+    var reBefore = decl.before.replace(reBLANK_LINE, '$1');
+    
+    // 有 *display: inline; 或 zoom: 1; 时就不插了
+    var hackTag = { inline: false, zoom: false }; 
 
-    insertDecl(decl, i, {
-      before: reBefore,
-      prop: '*zoom',
-      value: 1
+    decl.parent.each(function(neighbor) {
+      if (neighbor.before === '*' && neighbor.prop === 'display' && (neighbor.value === 'inline')) {
+        hackTag.inline = true;
+      }
+
+      if (neighbor.prop === 'zoom' && (neighbor.value === '1')) {
+        hackTag.zoom = true;
+      }
     });
-    insertDecl(decl, i, {
-      before: reBefore,
-      prop: '*display',
-      value: 'inline'
-    });
+
+    if (!hackTag.inline) {
+      insertDecl(decl, i, {
+        before: reBefore,
+        prop: '*display',
+        value: 'inline'
+      });
+    }
+
+    if (!hackTag.zoom) {
+      insertDecl(decl, i, {
+        before: reBefore,
+        prop: '*zoom',
+        value: 1
+      });
+    }
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -322,33 +322,33 @@ function ieInlineBlockHack(decl, i) {
   if (decl.prop == 'display' && decl.value == 'inline-block') {
 
     var reBefore = decl.before.replace(reBLANK_LINE, '$1');
-    
+
     // 有 *display: inline; 或 zoom: 1; 时就不插了
-    var hackTag = { inline: false, zoom: false }; 
+    var declFlag = { inline: false, zoom: false };
 
     decl.parent.each(function(neighbor) {
-      if (neighbor.before === '*' && neighbor.prop === 'display' && (neighbor.value === 'inline')) {
-        hackTag.inline = true;
+      if (neighbor.before.indexOf('*') !== -1 && neighbor.prop === 'display' && (neighbor.value === 'inline')) {
+        declFlag.inline = true;
       }
 
       if (neighbor.prop === 'zoom' && (neighbor.value === '1')) {
-        hackTag.zoom = true;
+        declFlag.zoom = true;
       }
     });
 
-    if (!hackTag.inline) {
-      insertDecl(decl, i, {
-        before: reBefore,
-        prop: '*display',
-        value: 'inline'
-      });
-    }
-
-    if (!hackTag.zoom) {
+    if (!declFlag.zoom) {
       insertDecl(decl, i, {
         before: reBefore,
         prop: '*zoom',
         value: 1
+      });
+    }
+
+    if (!declFlag.inline) {
+      insertDecl(decl, i, {
+        before: reBefore,
+        prop: '*display',
+        value: 'inline'
       });
     }
   }


### PR DESCRIPTION
如果含有 `display: inline-block;` 的声明里已经包含 IE hack，则不再重复插入 hack。避免编译第三方 CSS 库生成大量重复 hack。
