### PR TITLE
Skip rgba values in gradients and don't barf on inline svg

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ var reALL_PSEUDO   = /::(before|after|first-line|first-letter)/gi;
 var reNO_SETURL    = /url\(\s*(['"]?)([^\)'"]+)\1\s*\)/gi;
 var reBLANK_LINE   = /(\r\n|\n|\r)(\s*?\1)+/gi;
 var reBEFORE_AFTER = /::|:(before|after)/gi;
-var reBASE64       = /^data:image\/(png|jpg|jpeg|gif);base64,/;
+var reBASE64       = /^data:image\/png|svg\+xml;base64,/;
 
 
 
@@ -287,7 +287,7 @@ function ieRgbaHack(decl, i) {
     return str.length == 1 ? '0' + str : '' + str;
   }
   if ((decl.prop == 'background' || decl.prop == 'background-color') &&
-    decl.value.match(reRGBA)) {
+    decl.value.match(reRGBA) && !decl.value.match('gradient') ) {
     // rgba 转换为 AARRGGBB
     var colorR = pad(parseInt(RegExp.$1).toString(16));
     var colorG = pad(parseInt(RegExp.$2).toString(16));
@@ -357,9 +357,13 @@ function imageSetMixin(decl, i) {
         obj.whichImg = paths[j][3];
         if (obj.whichImg == "1x" || obj.whichImg == "1x") {
           // var normalSizes = sizeOf(getAbsolutePath(obj.url));
-          var normalSizes = reBASE64.test(obj.url) ?
+          try {
+            var normalSizes = reBASE64.test(obj.url) ?
             sizeOf(new Buffer(obj.url.replace(reBASE64, ''), 'base64')) :
             sizeOf(getAbsolutePath(obj.url));
+          } catch(e) {
+            return;
+          }
 
           normalWidth = normalSizes.width + 'px';
           normalHeight = normalSizes.height + 'px';
@@ -418,9 +422,14 @@ function imageSetMixin(decl, i) {
       // var retinaSizes = sizeOf(getAbsolutePath(retinaPaths[0][2]));
 
       // 计算 base64 图片尺寸
-      var retinaSizes = reBASE64.test(retinaPaths[0][2]) ?
+      try {
+        var retinaSizes = reBASE64.test(retinaPaths[0][2]) ?
         sizeOf(new Buffer(retinaPaths[0][2].replace(reBASE64, ''), 'base64')) :
         sizeOf(getAbsolutePath(retinaPaths[0][2]));
+      } catch(e) {
+        return;
+      }
+
 
       normalWidth = retinaSizes.width + 'px';
       normalHeight = retinaSizes.height + 'px';
@@ -471,7 +480,6 @@ var cssgraceRule = function(rule, i) {
     ieInlineBlockHack(decl, i);
     ieOpacityHack(decl, i);
     ieRgbaHack(decl, i);
-
     ellipsisMixin(decl, i);
     resizeMixin(decl, i);
     imageSetMixin(decl, i);


### PR DESCRIPTION
Fixes some issues I was having when using cssgrace