### PR TITLE
修正获取图片资源绝对路径Bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -500,6 +500,8 @@ function returnURL(val, reg) {
 var currentFilePath = '';
 //获取css文件中的资源的绝对地址
 function getAbsolutePath(sourcePath) {
+  //移除资源地址首位的'/'字符
+  sourcePath = sourcePath[0] === '/' ? sourcePath.replace('/', '') : sourcePath;
   //移除url中带有 ？参数的内容
   return path.resolve(currentFilePath, sourcePath.split("?")[0]);
 }


### PR DESCRIPTION
环境MAC OS，当background-image的url使用绝对地址时（如：background: url(/resource/foo.png) ），getAbsolutePath函数拿到的sourcePath参数首位字符是”/“，这会导致path.resolve认为sourcePath是root上的目录。